### PR TITLE
ui.py: Decode s to unicode

### DIFF
--- a/plugin/ui.py
+++ b/plugin/ui.py
@@ -342,6 +342,7 @@ class Config(ConfigListScreen, Screen):
 		self.changedWhere(self.cfgwhere)
 
 	def dataAvail(self, s):
+		s = s.decode()
 		print("[AutoBackup]", s.strip())
 		self["status"].appendText(s)
 


### PR DESCRIPTION
AutoBackup] b'Backup to /media/Uclan/backup/'
Traceback (most recent call last):
  File "/usr/lib/enigma2/python/Plugins/Extensions/AutoBackup/ui.py", line 346, in dataAvail
    self["status"].appendText(s)
  File "/usr/lib/enigma2/python/Components/ScrollLabel.py", line 113, in appendText
    self.setText(self.message + text, showBottom)
TypeError: can only concatenate str (not "bytes") to str
[ePyObject] (CallObject(<bound method Config.dataAvail of <class 'Plugins.Extensions.AutoBackup.ui.Config'>>,(b'Backup to /media/Uclan/backup/\n',)) failed)
[gRC] main thread is non-idle! display spinner!